### PR TITLE
Support collapsible admonitions

### DIFF
--- a/scripts/canvas_processing.py
+++ b/scripts/canvas_processing.py
@@ -784,6 +784,8 @@ def process_markdown_to_html(content: str, markdown_file_path: str, canvas_base_
         'toc',             # Table of contents
         'sane_lists',      # Better list handling
         'admonition',      # Note/warning blocks
+        'pymdownx.details',      # Support collapsible notes
+        'pymdownx.superfences',  # (requirement of pymdownx.details)
         'attr_list',       # Attribute lists
         'def_list',        # Definition lists
         'footnotes',       # Footnotes


### PR DESCRIPTION
Added `pymdownx.details` and `pymdownx.superfences` into the list of extensions.

They are not styled in any way though, but I actually wanted it that way. My highly advanced guess is to change `style_admonitions` for that. 🤷🏻 

P.S. Thanks for sharing the project, this has been useful for my course!